### PR TITLE
Clarify backend security group description

### DIFF
--- a/terraform/node-backend/security_group.tf
+++ b/terraform/node-backend/security_group.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "node_be_sg" {
   name        = "node_be-sg"
-  description = "Allow SSH and node_fe UI"
+  description = "Allow SSH and node_be API"
 
   ingress {
     from_port   = 22


### PR DESCRIPTION
## Summary
- clarify backend security group description to reference node_be API instead of frontend UI

## Testing
- `terraform fmt terraform/node-backend/security_group.tf`
- `terraform -chdir=terraform/node-backend init -backend=false`
- `terraform -chdir=terraform/node-backend validate`


------
https://chatgpt.com/codex/tasks/task_e_6896e91ab28483228eb2b5fffb26abe8